### PR TITLE
Add KataCR detection wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,31 @@ _Join the [Discord server](https://discord.gg/nqKRkyq2UU)!_
 6. Restart the bot, select the desired jobs to perform, then click the `Start` button.
 7. Enjoy the benefits of always-on farming with the py-clash-bot taking care of the heavy lifting for you.
 
+### Optional KataCR detection
+
+The project ships with an experimental wrapper around the
+[KataCR](https://github.com/wty-yy/KataCR) object-detection model. To
+use it you must clone the KataCR repository alongside the bot and ensure
+it is importable as `katacr`.
+
+```bash
+git clone https://github.com/wty-yy/KataCR
+```
+
+With the dependency available you can instantiate
+`pyclashbot.detection.KataCRDetector` to run YOLO-based detection in
+place of the traditional template matching utilities.
+
+### Build from source
+
+To create a distributable wheel and source tarball run:
+
+```bash
+uv build
+```
+
+The resulting artifacts will be placed in the `dist/` directory.
+
 ## Demo
 
 <img src="https://github.com/pyclashbot/py-clash-bot/blob/master/assets/demo-game.gif?raw=true" width="50%" alt="Game Demo"/><img src="https://github.com/pyclashbot/py-clash-bot/blob/master/assets/demo-gui.gif?raw=true" width="50%" alt="GUI Demo"/>

--- a/pyclashbot/detection/__init__.py
+++ b/pyclashbot/detection/__init__.py
@@ -5,8 +5,10 @@ from .image_rec import (
     get_first_location,
     pixel_is_equal,
 )
+from .katacr_detect import KataCRDetector
 
 __all__ = [
+    "KataCRDetector",
     "check_for_location",
     "compare_images",
     "find_references",

--- a/pyclashbot/detection/katacr_detect.py
+++ b/pyclashbot/detection/katacr_detect.py
@@ -1,0 +1,102 @@
+"""Wrapper around KataCR's detection model.
+
+This module provides a thin adapter to use the detection
+implementation from `https://github.com/wty-yy/KataCR`.
+It expects the `katacr` project to be available in the Python
+environment. The heavy lifting is performed by KataCR's
+`Infer` class while this wrapper converts screenshots from the
+bot into a format suitable for the model.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+from numpy.typing import NDArray
+
+if TYPE_CHECKING:  # pragma: no cover - used for type checking only
+    from katacr.detection.detect import Infer as KataCRInfer
+
+try:  # pragma: no cover - imported at runtime
+    # `Infer` is the high level detection helper used by KataCR's CLI.
+    from katacr.detection.detect import Infer as _KataCRInfer
+except Exception as exc:  # pragma: no cover - import guard
+    _KataCRInfer = None  # type: ignore[assignment]
+    _IMPORT_ERROR: Exception | None = exc
+else:  # pragma: no cover - executed only when import succeeds
+    _IMPORT_ERROR = None
+
+
+class KataCRDetector:
+    """Run object detection using KataCR's pretrained YOLO model.
+
+    Parameters
+    ----------
+    model_name:
+        Name of the model directory inside KataCR's ``logs`` folder.
+    load_id:
+        Checkpoint identifier to load.  Refer to KataCR's documentation
+        for available values.
+    path_model:
+        Optional explicit path to a model checkpoint.  When ``None`` the
+        default checkpoints bundled with KataCR are used.
+    iou_thre, conf_thre:
+        Threshold values forwarded to KataCR's non-maximum suppression
+        routine.
+
+    Notes
+    -----
+    The KataCR project is not distributed on PyPI.  To use this wrapper
+    the repository must be available and importable as ``katacr``.  If the
+    package cannot be imported an :class:`ImportError` is raised when
+    instantiating the detector.
+    """
+
+    def __init__(
+        self,
+        model_name: str = "YOLOv5_v0.5",
+        load_id: int = 150,
+        path_model: str | None = None,
+        iou_thre: float = 0.5,
+        conf_thre: float = 0.1,
+    ) -> None:
+        if _KataCRInfer is None:  # pragma: no cover - runtime check
+            raise ImportError(f"KataCR is not installed or failed to import. Original error: {_IMPORT_ERROR}")
+
+        self._infer: KataCRInfer = _KataCRInfer(
+            model_name=model_name,
+            load_id=load_id,
+            path_model=path_model,
+            iou_thre=iou_thre,
+            conf_thre=conf_thre,
+        )
+
+    def __call__(self, image: NDArray[np.uint8]) -> list[NDArray[np.float32]]:
+        """Detect objects within ``image``.
+
+        Parameters
+        ----------
+        image:
+            RGB image as a ``numpy.ndarray`` with shape ``(H, W, 3)`` and
+            ``dtype=uint8``.
+
+        Returns
+        -------
+        list[numpy.ndarray]
+            A list of bounding boxes in ``xywh`` format produced by the
+            KataCR model.  Each bounding box is a ``numpy.ndarray`` with
+            shape ``(N, 7)`` where the columns correspond to
+            ``x, y, w, h, conf, state, class``.  The exact format is
+            defined by KataCR's ``Infer`` implementation.
+        """
+
+        if image.ndim != 3:
+            raise ValueError("image must be a HxWx3 RGB array")
+        # The `Infer` class expects a numpy array with shape (1, H, W, 3).
+        batch: NDArray[np.uint8] = np.ascontiguousarray(image[None, ...])
+        boxes: list[NDArray[np.float32]] = self._infer(batch)
+        return boxes
+
+
+__all__ = ["KataCRDetector"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,3 +69,6 @@ line-length = 120
 
 [tool.isort]
 profile = "black"
+
+[tool.setuptools.packages.find]
+include = ["pyclashbot*"]


### PR DESCRIPTION
## Summary
- integrate KataCR YOLO detection via new `KataCRDetector` wrapper
- document how to enable KataCR and package build configuration

## Testing
- `uvx pre-commit run --files pyproject.toml pyclashbot/detection/katacr_detect.py README.md`
- `uv build`


------
https://chatgpt.com/codex/tasks/task_e_689a653cccbc83229512708ede821601